### PR TITLE
Send NAN(not a number) when the value is not available, instead of '0'.

### DIFF
--- a/DucoSerialHelpers.ino
+++ b/DucoSerialHelpers.ino
@@ -31,6 +31,13 @@ unsigned int duco_serial_rowCounter = 0;
  */
 void DucoSerialSendUpdate(String logPrefix, byte TaskIndex, byte BaseVarIndex, byte relIndex, int IDX, int valueDecimals)
 {
+    if (IDX == 0) {
+        /*
+         * Sending IDX 0 is not supported and most likely means the user has
+         * not configured this value; do not send an update.
+         */
+        return;
+    }
 
     LoadTaskSettings(TaskIndex);   
     ExtraTaskSettings.TaskDeviceValueDecimals[0] = valueDecimals;

--- a/_P152_DucoSerialBoxSensors.ino
+++ b/_P152_DucoSerialBoxSensors.ino
@@ -96,9 +96,9 @@ boolean Plugin_152(byte function, struct EventStruct *event, String& string)
             Serial.begin(115200, SERIAL_8N1);
             Plugin_152_init = true;
 
-            p152_duco_data[P152_DATA_BOX_TEMP] = 0.0; // box temp
-            p152_duco_data[P152_DATA_BOX_RH] = 0.0; // box rh
-            p152_duco_data[P152_DATA_BOX_CO2_PPM] = 0; // box CO2 ppm
+            p152_duco_data[P152_DATA_BOX_TEMP] = NAN; // box temp
+            p152_duco_data[P152_DATA_BOX_RH] = NAN; // box rh
+            p152_duco_data[P152_DATA_BOX_CO2_PPM] = NAN; // box CO2 ppm
 
             success = true;
             break;
@@ -136,6 +136,11 @@ boolean Plugin_152(byte function, struct EventStruct *event, String& string)
 void readBoxSensors(){
     addLog(LOG_LEVEL_DEBUG, PLUGIN_LOG_PREFIX_152 + "Start readBoxSensors");
     
+    /* Reset values to NAN; only update values we can correctly read */
+    for (int i = 0; i < P152_DATA_LAST; i++) {
+        p152_duco_data[i] = NAN;
+    }
+
     /*
      * Read box sensor information; this could contain CO2, Temperature and
      * Relative Humidity values, depending on the installed box sensors.
@@ -161,7 +166,7 @@ void readBoxSensors(){
                 duco_serial_buf[duco_serial_bytes_read] = '\0';
 
                 char *buf = (char*)duco_serial_buf;
-	            char *token = strtok(buf, "\r");
+	              char *token = strtok(buf, "\r");
                 unsigned int raw_value;
                 while (token != NULL) {
                     char logBuf[30];


### PR DESCRIPTION
This should fix Domoticz from showing incorrect readings.
It will also make 'devices' on ESPEasy show 'NaN' instead of '0.00' when sensor has not been installed.