### PR TITLE
Bugfix voor het vergelijken van de laatste byte van het networkID

### DIFF
--- a/lib/Duco/DucoCC1101.cpp
+++ b/lib/Duco/DucoCC1101.cpp
@@ -740,7 +740,7 @@ void DucoCC1101::checkForAck(){
 
 bool DucoCC1101::matchingNetworkId(uint8_t id[4]) 
 {
-	for (uint8_t i=0; i<3;i++){
+	for (uint8_t i=0; i<=3;i++){
 		if (id[i] != this->networkId[i]){
 			return false;
 		}


### PR DESCRIPTION
Bij het vergelijken van de laatste byte stond variabele i op 3. Aangezien 3 NIET lager is dan 3 werd de laatste byte niet meer vergeleken. Hierdoor reageerde de gateway ook op Ducoboxen uit de buurt waarvan de eerste drie bytes van het network id hetzelfde waren.