### PR TITLE
Commando toegevoegd waarmee je pakketjes kan versturen binnen het Duc…

### DIFF
--- a/_P150_DucoRFGateway.ino
+++ b/_P150_DucoRFGateway.ino
@@ -246,7 +246,7 @@ boolean Plugin_150(byte function, struct EventStruct *event, String& string)
 				PCONFIG(P150_CONFIG_DEVICE_ADDRESS) = PLUGIN_150_rf.getDeviceAddress();
 				SaveCustomTaskSettings(event->TaskIndex, (byte*)&PLUGIN_150_ExtraSettings, sizeof(PLUGIN_150_ExtraSettings));
 				SaveTaskSettings(event->TaskIndex);
-    		SaveSettings();
+    			SaveSettings();
 			}
 			
 			uint8_t numberOfLogMessages = PLUGIN_150_rf.getNumberOfLogMessages();
@@ -376,7 +376,58 @@ boolean Plugin_150(byte function, struct EventStruct *event, String& string)
 						addLog(LOG_LEVEL_INFO, PLUGIN_LOG_PREFIX_150 + F("Command ignored, please enable the task."));
 						printWebString += PLUGIN_LOG_PREFIX_150 + F("Command ignored, please enable the task.");
 					}
-				}
+			
+
+
+					}		
+					else if (cmd.equalsIgnoreCase(F("DUCOTESTMESSAGE")))
+					{
+
+						
+						// MESSAGETYPE
+						uint8_t messageType = atoi(param1.c_str()); // if empty value will be 0
+
+						// sourceAddress
+						String param2 = parseString(tmpString, 3);  // 
+						uint8_t sourceAddress = atoi(param2.c_str()); // if empty value will be 0
+
+						// destinationAddress
+						String param3 = parseString(tmpString, 4); 
+						uint8_t destinationAddress = atoi(param3.c_str()); // if empty value will be 0
+
+						// originalSourceAddress
+						String param4 = parseString(tmpString, 5); 
+						uint8_t originalSourceAddress = atoi(param4.c_str()); // if empty value will be 0
+
+						// originalDestinationAddress
+						String param5 = parseString(tmpString, 6); 
+						uint8_t originalDestinationAddress = atoi(param5.c_str()); // if empty value will be 0
+
+						String param6 = parseString(tmpString, 7); 
+						char hexValues[40];
+						param6.toCharArray(hexValues, 40);
+
+						unsigned char hexArray[20];
+						uint8_t dataBytes = 0;
+						PLUGIN_150_hexstringToHex(hexValues, hexArray, &dataBytes);
+
+						uint8_t* myuint8array = (uint8_t*)hexArray;
+						PLUGIN_150_rf.sendRawPacket(messageType, sourceAddress, destinationAddress, originalSourceAddress, originalDestinationAddress, myuint8array, dataBytes);
+
+							String log6 = PLUGIN_LOG_PREFIX_150 + F("Sent DUCOTESTMESSAGE to Duco Network: ");
+							log6 += messageType + ",";
+							log6 += sourceAddress + ",";
+							log6 += destinationAddress + ",";
+							log6 += originalSourceAddress + ",";
+							log6 += originalDestinationAddress + ",";
+							log6 += "bytes:";
+							log6 += dataBytes;
+
+							addLog(LOG_LEVEL_INFO, log6);
+							printWebString += log6;
+							success = true;
+					}
+
 
 					uint8_t numberOfLogMessages = PLUGIN_150_rf.getNumberOfLogMessages();
 					for(int i=0; i< numberOfLogMessages;i++){
@@ -514,6 +565,12 @@ return success;
 
 
 
+
+
+
+
+
+
 // IRQ handler:
 void PLUGIN_150_interruptHandler(void)
 {
@@ -580,4 +637,18 @@ void PLUGIN_150_Publishdata(struct EventStruct *event) {
    String log = PLUGIN_LOG_PREFIX_150 + " State: ";
    log += UserVar[event->BaseVarIndex];
    addLog(LOG_LEVEL_DEBUG, log);
+}
+
+
+
+void PLUGIN_150_hexstringToHex(char *hexString, unsigned char *hexArray, uint8_t *length ){
+	 const char *pos = hexString;
+
+     /* WARNING: no sanitization or error-checking whatsoever */
+    for (size_t count = 0; count < sizeof hexArray/sizeof *hexArray; count++) {
+        sscanf(pos, "%2hhx", &hexArray[count]);
+        pos += 2;
+		  length++;
+    }
+
 }

--- a/lib/Duco/DucoCC1101.cpp
+++ b/lib/Duco/DucoCC1101.cpp
@@ -9,6 +9,16 @@
 #include <SPI.h>
 
 
+// TODO: 
+// - Hoe reageert een bedieningsschakelaar wanneer er een networkcall is voor zijn network address?
+// bijvoorbeeld gw address = 5
+// Received message: SRC:1; DEST:0; ORG.SRC:1; ORG.DEST:0; Ntwrk:0001f947;Type:0; Bytes:10; Counter:12; RSSI:-68 (0x0D);
+// DATA: FF,05,  <<<< 
+
+
+
+
+
 // default constructor
 DucoCC1101::DucoCC1101(uint8_t counter, uint8_t sendTries) : CC1101()
 {
@@ -669,6 +679,8 @@ bool DucoCC1101::joinPacketValidNetworkId(){
 	return false;
 }
 
+
+
 void DucoCC1101::processJoin4Packet(){
 	// A join4 message is send to the networkID of the Ducobox (networkID is set by a join2 message). Check for matching network ID
 	if(matchingNetworkId(inDucoPacket.networkId)){
@@ -681,7 +693,6 @@ void DucoCC1101::processJoin4Packet(){
 			setLogMessage(F("processJoin4Packet: invalid join4 packet received, not our network ID."));
 	}
 }
-
 
 
 // data of a join4 message: 00 00 7C 3E XX YY
@@ -1292,12 +1303,27 @@ void DucoCC1101::sendTestMessage(){
 	return;
 }
 
-/*
-DucoPacket* DucoCC1101::TEST_getTestMessage(){
-	if(!matchingNetworkId(inDucoPacket.networkId)){ // check for network id
-		// reset dataLength
-		inDucoPacket.dataLength = 0;
+
+void DucoCC1101::sendRawPacket(uint8_t messageType, uint8_t sourceAddress, uint8_t destinationAddress, uint8_t originalSourceAddress, uint8_t originalDestinationAddress, uint8_t *data, uint8_t length){
+	
+	outDucoPacket.sourceAddress =  sourceAddress;
+	outDucoPacket.destinationAddress = destinationAddress;
+	outDucoPacket.originalSourceAddress =  originalSourceAddress;
+	outDucoPacket.originalDestinationAddress = originalDestinationAddress;
+	outDucoPacket.messageType = messageType;
+	outDucoPacket.commandLength = 0;
+
+	for(uint8_t i=0; i < length;i++){
+		outDucoPacket.data[i] = data[i];
 	}
-	return inDucoPacket;
+
+	outDucoPacket.dataLength = length;
+
+	memcpy(outDucoPacket.networkId,this->networkId,4);
+	outDucoPacket.counter = inDucoPacket.counter;
+
+	ducoToCC1101Packet(&outDucoPacket, &outMessage);
+
+	sendDataToDuco(&outMessage);
+	setLogMessage(F("Send raw Duco packet done!"));
 }
-*/

--- a/lib/Duco/DucoCC1101.h
+++ b/lib/Duco/DucoCC1101.h
@@ -109,7 +109,7 @@ class DucoCC1101 : protected CC1101
 
 
 		//String logMessages[10]; // to store some log messages from library
-		#define NUMBER_OF_LOG_STRING 10
+		#define NUMBER_OF_LOG_STRING 13
 		#define MAX_LOG_STRING_SIZE 250
 
 		uint8_t numberOfLogmessages = 0;
@@ -167,6 +167,8 @@ class DucoCC1101 : protected CC1101
 
 		uint8_t getMarcState(bool noLogMessage);
 
+
+		void sendRawPacket(uint8_t messageType, uint8_t sourceAddress, uint8_t destinationAddress, uint8_t originalSourceAddress, uint8_t originalDestinationAddress, uint8_t *data, uint8_t length);
 
 
 		//receive


### PR DESCRIPTION
Commando toegevoegd waarmee je pakketjes kan versturen binnen het Duco netwerk.

**Commando:** DUCOTESTMESSAGE,messageType, sourceAddress, destinationAddress, originalSourceAddress, originalDestinationAddress,data

**messageType**: 0 = networkmessage, 6 = ACK, 7 = message
**sourceAddress** = afzender
**destinationAddress** = ontvanger
**originalSourceAddress** = afzender (voor als het bericht is doorgestuurd)
**originalDestinationAddress** = ontvanger (voor als het bericht is doorgestuurd)
**data** = data in hex

**Bijvoorbeeld:**
- commando ventilatiestand op Hoog
- berichttype: normaal bericht (7)
- vanaf node 3
- naar node 1 (ducobox)

= DUCOTESTMESSAGE,7,3,1,3,1,400022000E6E